### PR TITLE
Add iOS 26 style glassy navbar

### DIFF
--- a/src/lib/Navbar.svelte
+++ b/src/lib/Navbar.svelte
@@ -1,0 +1,197 @@
+<script>
+	import { page } from '$app/stores';
+	
+	let { activeSection = 'home' } = $props();
+	
+	const navItems = [
+		{ name: 'Home', href: '#home', id: 'home' },
+		{ name: 'About', href: '#about', id: 'about' },
+		{ name: 'Projects', href: '#projects', id: 'projects' },
+		{ name: 'Contact', href: '#contact', id: 'contact' }
+	];
+	
+	// Function to check if item is active (based on current section in view)
+	function isActive(item) {
+		// For now, default to home being active
+		// You can implement intersection observer later to detect which section is in view
+		return item.id === 'home';
+	}
+</script>
+
+<nav class="navbar">
+	<div class="navbar-container">
+		<div class="navbar-menu">
+			{#each navItems as item}
+				<a 
+					href={item.href} 
+					class="nav-item" 
+					class:active={isActive(item)}
+					data-section={item.id}
+				>
+					{item.name}
+				</a>
+			{/each}
+		</div>
+	</div>
+</nav>
+
+<style>
+	.navbar {
+		position: fixed;
+		top: env(safe-area-inset-top, 0);
+		left: 0;
+		right: 0;
+		z-index: 1000;
+		
+		/* iOS 26 style glassy background */
+		background: rgba(0, 0, 0, 0.6);
+		backdrop-filter: blur(20px) saturate(180%);
+		-webkit-backdrop-filter: blur(20px) saturate(180%);
+		
+		/* Subtle border for definition */
+		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+		
+		/* Smooth transitions */
+		transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+		
+		/* Ensure proper backdrop behavior */
+		-webkit-backface-visibility: hidden;
+		backface-visibility: hidden;
+	}
+	
+	.navbar-container {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 0.75rem 1.5rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 60px;
+	}
+	
+
+	
+	.navbar-menu {
+		display: flex;
+		align-items: center;
+		gap: 2rem;
+	}
+	
+	.nav-item {
+		position: relative;
+		text-decoration: none;
+		color: white;
+		font-weight: 500;
+		font-size: 0.95rem;
+		padding: 0.5rem 0;
+		transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+		
+		/* Subtle text shadow for better readability */
+		text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+	}
+	
+	/* iOS-style underline effect with chroma animation */
+	.nav-item::after {
+		content: '';
+		position: absolute;
+		bottom: -2px;
+		left: 0;
+		right: 0;
+		height: 2px;
+		background: linear-gradient(
+			90deg,
+			#ff0057,
+			#fffa00,
+			#00ff85,
+			#00cfff,
+			#a700ff,
+			#ff0057
+		);
+		background-size: 200% 200%;
+		border-radius: 1px;
+		transform: scaleX(0);
+		transform-origin: center;
+		transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+		animation: chroma-rainbow 5s linear infinite;
+	}
+	
+	.nav-item:hover {
+		color: rgba(255, 255, 255, 0.9);
+		transform: translateY(-1px);
+		text-shadow: 0 2px 8px rgba(255, 255, 255, 0.2);
+	}
+	
+	.nav-item:hover::after {
+		transform: scaleX(1);
+	}
+	
+	/* Active state styling */
+	.nav-item.active {
+		color: white;
+		font-weight: 600;
+		opacity: 1;
+	}
+	
+	.nav-item.active::after {
+		transform: scaleX(1);
+		box-shadow: 0 0 10px rgba(255, 255, 255, 0.3);
+	}
+	
+	/* Rainbow animation for brand */
+	@keyframes chroma-rainbow {
+		0% {
+			background-position: 0% 50%;
+		}
+		50% {
+			background-position: 100% 50%;
+		}
+		100% {
+			background-position: 0% 50%;
+		}
+	}
+	
+	/* Responsive design */
+	@media screen and (max-width: 768px) {
+		.navbar-container {
+			padding: 0.5rem 1rem;
+			height: 56px;
+		}
+		
+		.navbar-menu {
+			gap: 1.5rem;
+		}
+		
+		.nav-item {
+			font-size: 0.9rem;
+		}
+	}
+	
+	@media screen and (max-width: 480px) {
+		.navbar-container {
+			padding: 0.5rem 0.75rem;
+		}
+		
+		.navbar-menu {
+			gap: 1rem;
+		}
+		
+		.nav-item {
+			font-size: 0.85rem;
+			padding: 0.25rem 0;
+		}
+	}
+	
+	/* Enhance backdrop blur on supported browsers */
+	@supports (backdrop-filter: blur(20px)) {
+		.navbar {
+			background: rgba(0, 0, 0, 0.4);
+		}
+	}
+	
+	/* Fallback for browsers without backdrop-filter */
+	@supports not (backdrop-filter: blur(20px)) {
+		.navbar {
+			background: rgba(0, 0, 0, 0.85);
+		}
+	}
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,9 @@
 <script>
 	import '../app.css';
+	import Navbar from '$lib/Navbar.svelte';
 
 	let { children } = $props();
 </script>
 
+<Navbar />
 {@render children()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -91,7 +91,7 @@ onMount(() => {
 });
 </script>
 
-<div class="relative bg-black overflow-hidden ios-full-height">
+<div class="relative bg-black overflow-hidden ios-full-height navbar-spacing">
     {#if mounted}
         <!-- Animated Background Blurs -->
         <div class="absolute inset-0 isolate">
@@ -292,6 +292,17 @@ onMount(() => {
     /* Force extension beyond viewport to eliminate bottom bar */
     min-height: 100vh;
     min-height: calc(100vh + env(safe-area-inset-bottom));
+}
+
+/* Navbar spacing to prevent overlap */
+.navbar-spacing {
+    padding-top: 60px; /* Default navbar height */
+}
+
+@media screen and (max-width: 768px) {
+    .navbar-spacing {
+        padding-top: 56px; /* Mobile navbar height */
+    }
 }
 
 /* Fix mobile blur rendering artifacts */


### PR DESCRIPTION
## 🎯 Overview
Implements the iOS 26 style glassy navbar as requested in issue #1.

## ✨ Features Implemented
- **Blurred background** with `backdrop-filter: blur(20px)` for that signature iOS glassy effect
- **White text** with subtle shadows for perfect readability
- **Rainbow underline animations** that inherit the chroma gradient from the main page name
- **Centered navigation** with clean, minimal design
- **Anchor-based navigation** using `#home`, `#about`, `#projects`, `#contact` for smooth scrolling

## 🏗️ Changes Made
- **Created `src/lib/Navbar.svelte`** - New glassy navbar component
- **Updated `+layout.svelte`** - Integrated navbar across all pages  
- **Updated `+page.svelte`** - Added proper spacing to prevent content overlap

## 🎨 Design Details
- Semi-transparent black background with 20px backdrop blur
- Responsive design that adapts to mobile and desktop
- Smooth animations and transitions throughout
- Safe area handling for iOS devices with notches
- Rainbow gradient underlines that match existing brand theming

## 📱 Responsive Features
- Adaptive navbar heights (60px desktop, 56px mobile)
- Proper touch targets and spacing for mobile interaction
- Graceful fallbacks for browsers without backdrop-filter support

Resolves #1